### PR TITLE
Build Nextjs app with calendar error

### DIFF
--- a/components/ui/BottomNav.tsx
+++ b/components/ui/BottomNav.tsx
@@ -2,9 +2,17 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { HomeIcon, MapPinIcon, PlusIcon, CalendarIcon, UserGroupIcon, UserIcon } from "@heroicons/react/24/outline";
+import { useEffect, useState } from "react";
 
 export default function BottomNav() {
-  const pathname = usePathname();
+  const [pathname, setPathname] = useState<string>('');
+  const [isClient, setIsClient] = useState(false);
+  const actualPathname = usePathname();
+
+  useEffect(() => {
+    setIsClient(true);
+    setPathname(actualPathname);
+  }, [actualPathname]);
 
   const navigation = [
     {


### PR DESCRIPTION
Make `BottomNav` component SSR-safe to fix `pathname is not defined` error during build.

The `usePathname()` hook was being called during server-side prerendering, causing a `ReferenceError` because `pathname` is only available client-side. This change ensures `pathname` is accessed only after client-side hydration, preventing build failures for pages like `/calendar`.

---
[Slack Thread](https://fsotd.slack.com/archives/D09B5TVMU1E/p1756137008198199?thread_ts=1756137008.198199&cid=D09B5TVMU1E)

<a href="https://cursor.com/background-agent?bcId=bc-5affe7cc-32a1-4799-9f62-04a84be877c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5affe7cc-32a1-4799-9f62-04a84be877c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

